### PR TITLE
Mistarget on Command `prefix` and `ping`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+.idea/

--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -3,6 +3,21 @@ module.exports = {
 	guildOnly: false,
 	description: 'Ping!',
 	execute(message) {
+		// duplicated code for convenience
+		let botMention = message.content.trim().split(' ')[0];
+		if (botMention.startsWith('<@') && botMention.endsWith('>')) {
+			botMention = botMention.slice(2, -1);
+
+			if (botMention.startsWith('!')) {
+				botMention = botMention.slice(1);
+			}
+		}
+
+		if (botMention !== message.client.user.id) {
+			console.log('This bot is not the target!');
+			return;
+		}
+
 		message.channel.send('Pong.');
 	},
 };

--- a/src/commands/prefix.js
+++ b/src/commands/prefix.js
@@ -5,6 +5,20 @@ module.exports = {
 	guildOnly: false,
 	description: 'Define prefix for bot',
 	async execute(message, args) {
+		let botMention = message.content.trim().split(' ')[0];
+		if (botMention.startsWith('<@') && botMention.endsWith('>')) {
+			botMention = botMention.slice(2, -1);
+
+			if (botMention.startsWith('!')) {
+				botMention = botMention.slice(1);
+			}
+		}
+
+		if (botMention !== message.client.user.id) {
+			console.log('This bot is not the target!');
+			return;
+		}
+
 		if (args.length === 0) {
 			const prefix = await PrefixUtil.getPrefix();
 


### PR DESCRIPTION
Fixes mistargetting with commands `prefix` and `ping` when using test bots or even simple commands such as `test ping`.